### PR TITLE
Existential functor for effects

### DIFF
--- a/src/Refract.purs
+++ b/src/Refract.purs
@@ -404,7 +404,7 @@ run elemId cmp st updateState = void $ element >>= render ui
     spec = R.spec st \this -> do
       st' <- R.readState this
       unsafeCoerceEff $ updateState $ st'
-      pure $ st # cmp \effect ->
+      pure $ st' # cmp \effect ->
         unsafeCoerceEff $ launchAff_ $
           interpretEffect this (unsafeCoerceEffect effect)
 


### PR DESCRIPTION
As I mentioned on slack, I think in your functor for effects you really wanted an existential sort of thing, so I made another functor that gets passed to 

How it works is when you use `runExists` you don't know what type `r` has, so you basically have no choice but to apply the functor `r -> next` to the result of the modify or effect function. (This pattern is reminiscent of an `Invariant` functor, so I provided that instance.) You typically plug in `r` for `next` (using `id`) to obtain the result on the outside, but from there you can map over `next` as usual without worrying about what `r` was anymore.

This helps us use safer coerces in general, and I spotted a couple places where `unsafeCoerceEff` would be more appropriate. (`unsafeCoerceEffect` could be written in terms of mapping with `unsafeCoerceAff`, but `unsafeCoerce` is more efficient.)

Everything should work the same, but be a little bit safer now ;)

Cheers!